### PR TITLE
Version 1 prep

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "URIs"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/URIs.jl/graphs/contributors"]
-version = "0.1.0"
+version = "1.0.0"
 
 [compat]
 julia = "1"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,6 @@ Identifiers, as defined in [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt).
 
 ```@docs
 URI
-resource
 queryparams
 absuri
 escapeuri

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -1,7 +1,7 @@
 module URIs
 
 export URI,
-       resource, queryparams, absuri,
+       queryparams, absuri,
        escapeuri, unescapeuri, escapepath
 
 import Base.==
@@ -34,10 +34,6 @@ component parts in the following `SubString` fields:
   * `path` e.g `"/"`
   * `query` e.g. `"Foo=1&Bar=2"`
   * `fragment`
-
-The `resource(::URI)` function returns a target-resource string for the URI
-[RFC7230 5.3](https://tools.ietf.org/html/rfc7230#section-5.3).
-e.g. `"\$path?\$query#\$fragment"`.
 
 The `queryparams(::URI)` function returns a `Dict` containing the `query`.
 """
@@ -199,17 +195,6 @@ isabspath(uri::URI) = startswith(uri.path, "/") && !startswith(uri.path, "//")
                     a.query       == b.query       &&
                     a.fragment    == b.fragment    &&
                     a.userinfo    == b.userinfo
-
-"""
-    resource(::URI)
-
-The `resource(::URI)` function returns a target-resource string for the URI
-[RFC7230 5.3](https://tools.ietf.org/html/rfc7230#section-5.3).
-e.g. `"\$path?\$query#\$fragment"`.
-"""
-resource(uri::URI) = string( isempty(uri.path)     ? "/" :     uri.path,
-                            !isempty(uri.query)    ? "?" : "", uri.query,
-                            !isempty(uri.fragment) ? "#" : "", uri.fragment)
 
 normalport(uri::URI) = uri.scheme == "http"  && uri.port == "80" ||
                        uri.scheme == "https" && uri.port == "443" ?


### PR DESCRIPTION
* Remove `resource()` (see notes in #2)
* Bump to version 1.0.0 as this code has been stable within HTTP.jl for a long time.