### PR TITLE
Make queryparams() always return Dict{String,String}

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -269,9 +269,9 @@ convention — see [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.4).
 queryparams(uri::URI) = queryparams(uri.query)
 
 function queryparams(q::AbstractString)
-    Dict(unescapeuri(decodeplus(k)) => unescapeuri(decodeplus(v))
-        for (k,v) in ([split(e, "=")..., ""][1:2]
-            for e in split(q, "&", keepempty=false)))
+    Dict{String,String}(unescapeuri(decodeplus(k)) => unescapeuri(decodeplus(v))
+                        for (k,v) in ([split(e, "=")..., ""][1:2]
+                                      for e in split(q, "&", keepempty=false)))
 end
 
 # Validate known URI formats

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -442,6 +442,7 @@ urltests = URLTest[
     end
 
     @testset "Query Params" begin
+        @test queryparams(URI("http://example.com"))::Dict{String,String} == Dict()
         @test queryparams(URI("https://httphost/path1/path2;paramstring?q=a&p=r#frag")) == Dict("q"=>"a","p"=>"r")
         @test queryparams(URI("https://foo.net/?q=a&malformed")) == Dict("q"=>"a","malformed"=>"")
     end


### PR DESCRIPTION
Fixes #8