### PR TITLE
Fix the `absuri` function to correctly handle relative location paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
           - windows-latest
         arch:
           - x64
+        exclude:
+          - os: windows-latest
+            version: 'nightly'
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/test/absuri.jl
+++ b/test/absuri.jl
@@ -1,0 +1,15 @@
+@testset "absuri.jl" begin
+    cases = [
+        ("https://en.wikipedia.org/api/rest_v1/page/summary/Potatoes", "Potato", "https://en.wikipedia.org/api/rest_v1/page/summary/Potato"),
+        ("https://en.wikipedia.org/api/rest_v1/page/summary/Potatoes", "./Potato", "https://en.wikipedia.org/api/rest_v1/page/summary/Potato"),
+        ("https://en.wikipedia.org/api/rest_v1/page/summary/Potatoes", "/foo/bar/baz", "https://en.wikipedia.org/foo/bar/baz"),
+        ("https://en.wikipedia.org/api/rest_v1/page/summary/Potatoes", "https://julialang.org/foo/bar/baz", "https://julialang.org/foo/bar/baz"),
+    ]
+    for case in cases
+        url = case[1]
+        location = case[2]
+        actual_output = URIs.absuri(location, url)
+        expected_output = URIs.URI(case[3])
+        @test actual_output == expected_output
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Test
 
 include("uri.jl")
 include("url.jl")
+include("absuri.jl")


### PR DESCRIPTION
This pull request fixes the `absuri` function to correctly handle relative location paths.

Fixes https://github.com/JuliaWeb/HTTP.jl/issues/435
Fixes https://github.com/JuliaWeb/HTTP.jl/issues/626