### PR TITLE
Improvements to `URIs.splitpath`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "URIs"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/URIs.jl/graphs/contributors"]
-version = "1.1.0"
+version = "1.2.0"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
* Add a version taking a URI
* Add rstrip_trailing_segment option to splitpath
* Make robust to any trailing query or fragment parts when a string (rather than URI) is provided.
* Fix bug where single character paths would become empty
* Add more tests

Fixes #14