### PR TITLE
Added try/catch into unescapeuri()

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -358,7 +358,7 @@ function unescapeuri(str)
         if c == '%'
             c1 = read(io, Char)
             c = read(io, Char)
-            write(out, parse(UInt8, string(c1, c); base=16))
+            write(out, try parse(UInt8, string(c1, c); base=16) catch e; @warn e; string(c1, c) end)
         else
             write(out, c)
         end

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -348,17 +348,21 @@ decodeplus(q) = replace(q, '+' => ' ')
 
 Percent-decode a string according to the URI escaping rules.
 """
-function unescapeuri(str)
+function unescapeuri(str::String; malformatted_error = true)
     occursin("%", str) || return str
     out = IOBuffer()
     i = 1
     io = IOBuffer(str)
-    while !eof(io)
+    while !eof(io) 
         c = read(io, Char)
-        if c == '%'
+        if (c == '%') & malformatted_error
             c1 = read(io, Char)
             c = read(io, Char)
-            write(out, try parse(UInt8, string(c1, c); base=16) catch e; @warn e; string(c1, c) end)
+            write(out, parse(UInt8, string(c1, c); base=16))
+        elseif (!malformatted_error) & (c == '%') & !eof(io)
+            c1 = read(io, Char)
+            c = read(io, Char)
+            write(out, try parse(UInt8, string(c1, c); base=16) catch; string(c1, c) end)
         else
             write(out, c)
         end


### PR DESCRIPTION
In the current version unescapeuri() gives an error if the %... character is an invalid base 16. However some url parameters can have %... as part of their value. 
For those cases the function now gives a warning but returns the string without changes and doesn't throw an error.