### PR TITLE
Add a function to resolve URI references relative to a base URI

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -57,6 +57,7 @@ absuri
 escapeuri
 unescapeuri
 escapepath
+resolvereference
 URIs.splitpath
 Base.isvalid(::URI)
 ```

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -594,10 +594,11 @@ function resolveref_merge(base, ref)
     if base.host != "" && base.path == ""
         "/" * ref.path
     else
-        last_slash = findprev('/', base.path, lastindex(base.path))
+        last_slash = findprev("/", base.path, lastindex(base.path))
         if last_slash === nothing
             ref.path
         else
+            last_slash = first(last_slash)
             base.path[1:last_slash] * ref.path
         end
     end

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -523,7 +523,24 @@ end
     resolvereference(base, ref)
 
 Resolve a URI reference `ref` relative to the absolute base URI `base`,
-complying with RFC 3986 Section 5.2.
+complying with RFC 3986 Section 5.2. `base` and `ref` should both be
+of type `Union{URI,AbstractString}`.
+
+If `ref` is an absolute URI, then this function just returns a copy
+of `ref`.
+
+# Examples
+
+```jldoctest; setup = :(using URIs)
+julia> u = resolvereference("http://example.org/foo/bar/", "/baz/")
+URI("http://example.org/baz/")
+
+julia> resolvereference(u, "./hello/world")
+URI("http://example.org/baz/hello/world")
+
+julia> resolvereference(u, "http://localhost:8000")
+URI("http://localhost:8000")
+```
 """
 function resolvereference(base::URI, ref::URI)
     # In the case where the second URI is absolute, we just return the

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -548,18 +548,17 @@ function resolvereference(base::URI, ref::URI)
     #
     # We also default to just returning the reference when the base URI is
     # non-absolute.
-    if base.scheme == "" || ref.scheme != ""
+    if isempty(base.scheme) || !isempty(ref.scheme)
         return ref
     end
 
-    host, port, path, query = if ref.host != ""
+    host, port, path, query = if !isempty(ref.host)
         ref.host, ref.port, ref.path, ref.query
     else
-        path, query = if ref.path == ""
-            base.path, (ref.query == "") ? base.query : ref.query
+        path, query = if isempty(ref.path)
+            base.path, isempty(ref.query) ? base.query : ref.query
         else
             path = startswith(ref.path, "/") ? ref.path : resolveref_merge(base, ref)
-            #path = remove_dot_segments(path)
             path, ref.query
         end
         base.host, base.port, path, query
@@ -568,7 +567,7 @@ function resolvereference(base::URI, ref::URI)
     path = normpath(path)
     scheme = base.scheme
     fragment = ref.fragment
-    userinfo = (ref.userinfo == "") ? base.userinfo : ref.userinfo
+    userinfo = isempty(ref.userinfo) ? base.userinfo : ref.userinfo
 
     URI(;
         scheme=scheme,
@@ -591,7 +590,7 @@ Implementation of the "merge" routine described in RFC 3986 Sec. 5.2.3 for mergi
 a relative-path reference with the path of the base URI.
 """
 function resolveref_merge(base, ref)
-    if base.host != "" && base.path == ""
+    if !isempty(base.host) && isempty(base.path)
         "/" * ref.path
     else
         last_slash = findprev("/", base.path, lastindex(base.path))

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -520,14 +520,12 @@ function Base.joinpath(uri::URI, parts::String...)
 end
 
 """
-    resolvereference(base, ref)
+    resolvereference(base::Union{URI,AbstractString}, ref::Union{URI,AbstractString}) -> URI
 
 Resolve a URI reference `ref` relative to the absolute base URI `base`,
-complying with RFC 3986 Section 5.2. `base` and `ref` should both be
-of type `Union{URI,AbstractString}`.
+complying with [RFC 3986 Section 5.2](https://tools.ietf.org/html/rfc3986#section-5.2).
 
-If `ref` is an absolute URI, then this function just returns a copy
-of `ref`.
+If `ref` is an absolute URI, return `ref` unchanged.
 
 # Examples
 
@@ -580,8 +578,7 @@ function resolvereference(base::URI, ref::URI)
     )
 end
 
-resolvereference(base, ref) = resolvereference(URI(base), ref)
-resolvereference(base::URI, ref) = resolvereference(base, URI(ref))
+resolvereference(base, ref) = resolvereference(URI(base), URI(ref))
 
 """
     resolveref_merge(base, ref)


### PR DESCRIPTION
RFC 3986 Section 5.2 (https://tools.ietf.org/html/rfc3986#section-5.2) defines an method for resolving references relative to a base URI. This pull request adds the `resolvereference` function in order to achieve this functionality, which attempts to comply with the algorithm defined in Section 5.2.2.

Closes #18.