### PR TITLE
Fix and clarify encoding rules in documentation

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -21,10 +21,12 @@ end
 
 A type representing a URI (e.g. a URL). Can be constructed from distinct parts using the various
 supported keyword arguments, or from a string. The `URI` constructors will automatically escape any provided
-`query` arguments, typically provided as `"key"=>"value"::Pair` or `Dict("key"=>"value")`.
-Note that multiple values for a single query key can provided like `Dict("key"=>["value1", "value2"])`.
+`query` arguments, typically provided as `"key"=>"value"::Pair` or `Dict("key"=>"value")`. For all other components, you
+need to manually percent encode them before passing them to the `URI` constructor. Note that multiple values for a
+single query key can provided like `Dict("key"=>["value1", "value2"])`, in which case the constructor will
+percent encode _only_ the values you pass in as the `query` part.
 
-When constructing a `URI` from a `String`, you need to first unescape that string: `URI( URIs.unescapeuri(str) )`.
+When constructing a `URI` from a `String`, you need to ensure that the string is correctly percent encoded already.
 
 The `URI` struct stores the complete URI in the `uri::String` field and the
 component parts in the following `SubString` fields:
@@ -37,6 +39,9 @@ component parts in the following `SubString` fields:
   * `fragment`
 
 The `queryparams(::URI)` function returns a `Dict` containing the `query`.
+
+Note that you manually need to percent decode the content of the individual component fields before you further use
+their content, as they are returned in percent-encoded form.
 """
 struct URI
     uri::String


### PR DESCRIPTION
I think the part about `URI(URIs.unescapeuri(str))` is just wrong, the proper use seems to be that one needs to pass in exactly the opposite, namely a correctly encoded uri. CC @fonsp, I think you added that language, does that seem right to you?

Also clarifies when and how one needs to percent encode and decode in general.