### PR TITLE
Fix incorrect path normalization

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -459,7 +459,7 @@ normpath(url::URI) =
 _tail(s, prefix) = last(s, length(s) - length(prefix))
 function _pop_segment(buf)
     last_slash = findlast('/', buf)
-    (last_slash === nothing) ? "" : buf[begin:prevind(buf, last_slash)]
+    (last_slash === nothing) ? "" : buf[firstindex(buf):prevind(buf, last_slash)]
 end
 
 function normpath(p::AbstractString)
@@ -495,7 +495,7 @@ function normpath(p::AbstractString)
                 output = output * p
                 last(p, 0)
             else
-                prefix = p[begin:prevind(p, next_slash)]
+                prefix = p[firstindex(p):prevind(p, next_slash)]
                 output = output * prefix
                 _tail(p, prefix)
             end

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -459,7 +459,7 @@ normpath(url::URI) =
 _tail(s, prefix) = last(s, length(s) - length(prefix))
 function _pop_segment(buf)
     last_slash = findlast('/', buf)
-    (last_slash === nothing) ? "" : first(buf, last_slash-1)
+    (last_slash === nothing) ? "" : buf[begin:prevind(buf, last_slash)]
 end
 
 function normpath(p::AbstractString)
@@ -490,12 +490,12 @@ function normpath(p::AbstractString)
             last(p, 0)
         # Condition E
         else
-            next_slash = findnext(isequal('/'), p, 2)
+            next_slash = findnext(isequal('/'), p, nextind(p, 1))
             if (next_slash === nothing)
                 output = output * p
                 last(p, 0)
             else
-                prefix = first(p, next_slash - 1)
+                prefix = p[begin:prevind(p, next_slash)]
                 output = output * prefix
                 _tail(p, prefix)
             end

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -444,7 +444,9 @@ splitpath(uri::URI; kws...) = splitpath(uri.path; kws...)
 """
     URIs.normpath(url)
 
-Normalize the path portion of a URI by removing dot segments.
+Normalize the path portion of a URI by removing dot segments. This function
+corresponds to the `remove_dot_segments` function described in Sec. 5.2.4 of
+IETF RFC 3986.
 
 Refer to:
 * https://tools.ietf.org/html/rfc3986#section-5.2.4
@@ -453,31 +455,54 @@ normpath(url::URI) =
     URI(scheme=url.scheme, userinfo=url.userinfo, host=url.host, port=url.port,
         path=normpath(url.path), query=url.query, fragment=url.fragment)
 
+# normpath helper functions
+_tail(s, prefix) = last(s, length(s) - length(prefix))
+function _pop_segment(buf)
+    last_slash = findlast('/', buf)
+    (last_slash === nothing) ? "" : first(buf, last_slash-1)
+end
+
 function normpath(p::AbstractString)
-    if isempty(p) || p == "/"
-        return p
-    elseif p == "." || p == ".."
-        return "/"
-    end
-    buf = String[]
-    for part in splitpath(p)
-        if part == "."
-            continue
-        elseif part == ".."
-            isempty(buf) || pop!(buf)
+    # Ref: IETF RFC 3986 Sec. 5.2.4
+    # https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.4
+    output = ""
+
+    while !isempty(p)
+        # Condition A
+        p = if startswith(p, "./")
+            _tail(p, "./")
+        elseif startswith(p, "../")
+            _tail(p, "../")
+        # Condition B
+        elseif startswith(p, "/./")
+            "/" * _tail(p, "/./")
+        elseif p == "/."
+            "/"
+        # Condition C
+        elseif startswith(p, "/../")
+            output = _pop_segment(output)
+            "/" * _tail(p, "/../")
+        elseif p == "/.."
+            output = _pop_segment(output)
+            "/"
+        # Condition D
+        elseif occursin(r"^\.+$", p)
+            last(p, 0)
+        # Condition E
         else
-            push!(buf, part)
+            next_slash = findnext(isequal('/'), p, 2)
+            if (next_slash === nothing)
+                output = output * p
+                last(p, 0)
+            else
+                prefix = first(p, next_slash - 1)
+                output = output * prefix
+                _tail(p, prefix)
+            end
         end
     end
-    out = join(buf, '/')
-    # Preserve leading and trailing slashes if present, but don't duplicate them
-    if startswith(p, '/') && !startswith(out, '/')
-        out = "/" * out
-    end
-    if (endswith(p, '/') || endswith(p, '.')) && !endswith(out, '/')
-        out *= "/"
-    end
-    out
+
+    output
 end
 
 absuri(u, context) = absuri(URI(u), URI(context))

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -531,6 +531,8 @@ urltests = URLTest[
         # "Abnormal" examples in https://tools.ietf.org/html/rfc3986#section-5.4.2
         checknp("http://a/b/c/d/../../../g", "http://a/g")
         checknp("http://a/b/c/d/../../../../g", "http://a/g")
+        checknp("http://a/b/c/g.", "http://a/b/c/g.")
+        checknp("http://a/b/c/g..", "http://a/b/c/g..")
 
         # "Normal" examples
         checknp("http://a", "http://a")
@@ -553,6 +555,7 @@ urltests = URLTest[
     end
 
     @testset "resolvereference" begin
+        # Reference: IETF RFC 3986: https://datatracker.ietf.org/doc/html/rfc3986
         # Tests for resolving URI references, as defined in Section 5.4
 
         # Perform some basic tests resolving absolute and relative references to a base URI
@@ -601,6 +604,25 @@ urltests = URLTest[
         # "Abnormal examples" specified in Section 5.4.2
         @test resolvereference(base, "../../../g") == URI("http://a/g")
         @test resolvereference(base, "../../../../g") == URI("http://a/g")
+
+        @test resolvereference(base, "/./g") == URI("http://a/g")
+        @test resolvereference(base, "/../g") == URI("http://a/g")
+        @test resolvereference(base, "g.") == URI("http://a/b/c/g.")
+        @test resolvereference(base, ".g") == URI("http://a/b/c/.g")
+        @test resolvereference(base, "g..") == URI("http://a/b/c/g..")
+        @test resolvereference(base, "..g") == URI("http://a/b/c/..g")
+
+        @test resolvereference(base, "./../g") == URI("http://a/b/g")
+        @test resolvereference(base, "./g/.") == URI("http://a/b/c/g/")
+        @test resolvereference(base, "g/./h") == URI("http://a/b/c/g/h")
+        @test resolvereference(base, "g/../h") == URI("http://a/b/c/h")
+        @test resolvereference(base, "g;x=1/./y") == URI("http://a/b/c/g;x=1/y")
+        @test resolvereference(base, "g;x=1/../y") == URI("http://a/b/c/y")
+
+        @test resolvereference(base, "g?y/./x") == URI("http://a/b/c/g?y/./x")
+        @test resolvereference(base, "g?y/../x") == URI("http://a/b/c/g?y/../x")
+        @test resolvereference(base, "g#s/./x") == URI("http://a/b/c/g#s/./x")
+        @test resolvereference(base, "g#s/../x") == URI("http://a/b/c/g#s/../x")
     end
 
     @testset "error testing tools" begin


### PR DESCRIPTION
This pull request fixes #20, by rewriting the `normpath` routine to operate more closely to its corresponding function in IETF RFC 3986 (the `remove_dot_segments` function described in Sec. 5.2.4).

In addition to rewriting `normpath`, I've added the "abnormal" test cases that triggered #20 to the test suite for `normpath`. I've also added the full list of abnormal test cases described in Sec. 5.4 for the `resolvereference` function, including the erroneous case, which should hopefully help catch errors like this more often.

Closes #20.