### PR TITLE
Bump minimum Julia version tested to Julia 1.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/Juli
 version = "1.3.1"
 
 [compat]
-julia = "1"
+julia = "1.6"
 
 [extras]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"


### PR DESCRIPTION
I'm not sure whether there's any reason this package should continue being tested to support Julia 1.0 since it's no longer officially supported. Seeing that [HTTP.jl's unit testing pipeline only tests Julia 1.6](https://github.com/JuliaWeb/HTTP.jl/blob/7cab2ab077825aff366cc8e1e34db9d5566654bd/.github/workflows/ci.yml#L20-L24), I figured that it would make sense to bump the minimum version of Julia tested by URIs.jl to the new LTS as well.