### PR TITLE
splitfilepath such as  Base.Filesystem.joinpath(splitfilepath(urlpath)) == fspath

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -448,7 +448,12 @@ function splitfilepath(path::AbstractString; rstrip_empty_segment::Bool=true)
     end
     segs
 end
-    
+
+function splitfilepath(a::URI; kwargs...)
+    a.scheme == "file" || throw(ArgumentError("a = $a"))
+    splitfilepath(a.path; kwargs...)
+end
+
 function _splitpath(path::AbstractString; rstrip_empty_segment::Bool=true)
     segments = String[]
     n = ncodeunits(path)

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -1,7 +1,7 @@
 module URIs
 
 export URI,
-       queryparams, queryparampairs, absuri,
+       queryparams, queryparampairs, absuri, splitfilepath,
        escapeuri, unescapeuri, escapepath,
        resolvereference
 

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -457,7 +457,7 @@ urltests = URLTest[
         @test URIs.splitpath("/foo/bar") == ["foo", "bar"]
     end
     end
-
+      
     @testset "splitfilepath" begin
         @static if Sys.iswindows()
             data = [
@@ -476,7 +476,10 @@ urltests = URLTest[
             @test URI(url).path == urlpath
             @test splitfilepath(urlpath) == fs_segs
             @test Base.Filesystem.joinpath(fs_segs...) == fspath
+
+            @test splitfilepath(url) == fs_segs
         end
+        @test_throws ArgumentError splitfilepath(URI("http://foo.com"))
     end
 
     @testset "Parse" begin


### PR DESCRIPTION
Add new `splitfilepath` function such as  `Base.Filesystem.joinpath(splitfilepath(url)) == fspath` if url has a "file" scheme
where fspath is the expected filesystem path

One can also add
```julia
filepath(a::URI; kwargs...) = joinpath(splitfilepath(a; kwargs...)...) # will throws if a has not a "file" scheme
```