### PR TITLE
Support AbstactString in escapeuri

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -332,8 +332,7 @@ function _bytes end
 _bytes(s::SubArray{UInt8}) = unsafe_wrap(Array, pointer(s), length(s))
 
 _bytes(s::Union{Vector{UInt8}, Base.CodeUnits}) = _bytes(String(s))
-_bytes(s::String) = codeunits(s)
-_bytes(s::SubString{String}) = codeunits(s)
+_bytes(s::AbstractString) = codeunits(s)
 
 _bytes(s::Vector{UInt8}) = s
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,12 @@ using Test
 
 include("uri.jl")
 include("url.jl")
+
+# https://github.com/JuliaWeb/URIs.jl/issues/42
+struct CustomString <: AbstractString
+    str::String
+end
+
+Base.codeunits(x::CustomString) = codeunits(x.str)
+
+@test URIs.escapeuri(CustomString("http://example.com")) == URIs.escapeuri("http://example.com")


### PR DESCRIPTION
Fixes https://github.com/JuliaWeb/URIs.jl/issues/42.