### PR TITLE
Consistent return type for `queryparampairs`

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -298,7 +298,7 @@ convention — see [RFC 3986](https://tools.ietf.org/html/rfc3986#section-3.4).
 queryparampairs(uri::URI) = queryparampairs(uri.query)
 
 function queryparampairs(q::AbstractString)
-    [unescapeuri(decodeplus(k)) => unescapeuri(decodeplus(v))
+    Pair{String,String}[unescapeuri(decodeplus(k)) => unescapeuri(decodeplus(v))
                         for (k,v) in ([split(e, "=")..., ""][1:2]
                                       for e in split(q, "&", keepempty=false))]
 end

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -515,7 +515,8 @@ urltests = URLTest[
         @test queryparams(URI("http://example.com"))::Dict{String,String} == Dict()
         @test queryparams(URI("https://httphost/path1/path2;paramstring?q=a&p=r#frag")) == Dict("q"=>"a","p"=>"r")
         @test queryparams(URI("https://foo.net/?q=a&malformed")) == Dict("q"=>"a","malformed"=>"")
-        @test queryparampairs(URI("http://example.com?a=b&a=c&a=d"))::Vector{Pair{String, String}} == ["a" => "b", "a" => "c", "a" => "d"]
+        @test queryparampairs(URI("http://example.com"))::Vector{Pair{String, String}} == Vector()
+        @test queryparampairs(URI("http://example.com?a=b&a=c&a=d")) == ["a" => "b", "a" => "c", "a" => "d"]
     end
 
     @testset "Parse Errors" begin


### PR DESCRIPTION
Makes `queryparampairs` always return a `Vector{Pair{String,String}}`. Old would return a `Vector{Any}` when no elements were found:

Old behaviour:
```julia
julia> queryparampairs("a=b")
1-element Vector{Pair{String, String}}:
 "a" => "b"

julia> queryparampairs("")
Any[]
```
New behaviour:
```julia
julia> queryparampairs("a=b")
1-element Vector{Pair{String, String}}:
 "a" => "b"

julia> queryparampairs("")
Pair{String, String}[]
```