### PR TITLE
Add ::Pair dispatch to escapeuri

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "URIs"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/URIs.jl/graphs/contributors"]
-version = "1.5.0"
+version = "1.5.1"
 
 [compat]
 julia = "1.6"

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -367,8 +367,10 @@ encoded within the query part of a URI.
 """
 escapeuri(key, value) = string(escapeuri(key), "=", escapeuri(value))
 escapeuri(key, values::Vector) = escapeuri(key => v for v in values)
-escapeuri(query) = isempty(query) ? absent : join((escapeuri(k, v) for (k,v) in query), "&")
 escapeuri(nt::NamedTuple) = escapeuri(pairs(nt))
+escapeuri(p::Pair) = escapeuri((p,))
+# Fallback method that expects the query argument to iterate key-value pairs
+escapeuri(query) = isempty(query) ? absent : join((escapeuri(k, v) for (k,v) in query), "&")
 
 decodeplus(q) = replace(q, '+' => ' ')
 

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -408,6 +408,7 @@ urltests = URLTest[
         @test URI(URI("http://google.com/user")) == URI("http://google.com/user")
         @test URI(URI("http://google.com/user"); query=["key" => "value"]) == URI("http://google.com/user?key=value")
         @test URI("http://google.com/user"; query=["key" => "value"]) == URI("http://google.com/user?key=value")
+        @test URI("http://google.com/user"; query="key" => "value") == URI("http://google.com/user?key=value")
 
         # Precondition error messages refer to the function name (#32)
         @test_throws ArgumentError("URI() requires `scheme in uses_authority || isempty(host)`") URI(; host="example.com")


### PR DESCRIPTION
The docstring for `URIs.URI` claims that passing a single query argument
as a `Pair` is valid. However, since there is no method specifically for
pairs the fallback method is used. The fallback method assumes the
argument iterates key-value pairs, but since `Pair` iterates the two
components this will simply encode the first characters of the key-value
pair instead.