### PR TITLE
Fix leading slash for abspath in joinpath

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -593,7 +593,7 @@ function Base.joinpath(uri::URI, parts::String...)
         end
     end
 
-    if isempty(uri.path)
+    if isempty(uri.path) && !startswith(path, "/")
         path = "/" * path
     end
     return URI(uri; path=normpath(path))

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -462,7 +462,7 @@ urltests = URLTest[
         @test URIs.splitpath("/foo/bar") == ["foo", "bar"]
     end
     end
-      
+
     @testset "splitfilepath" begin
         @static if Sys.iswindows()
             data = [
@@ -597,6 +597,9 @@ urltests = URLTest[
         @test joinpath(URIs.URI("http://a.b.c/d/f"), "/b", "c") == URI("http://a.b.c/b/c")
         @test joinpath(URIs.URI("http://a.b.c/"), "b", "c") == URI("http://a.b.c/b/c")
         @test joinpath(URIs.URI("http://a.b.c"), "b", "c") == URI("http://a.b.c/b/c")
+        @test joinpath(URIs.URI("http://a.b.c"), "/b/c/") == URI("http://a.b.c/b/c/")
+        @test joinpath(URIs.URI("http://a.b.c"), "/b/c") == URI("http://a.b.c/b/c")
+        @test joinpath(URIs.URI("http://a.b.c"), "/b", "c") == URI("http://a.b.c/b/c")
     end
 
     @testset "resolvereference" begin


### PR DESCRIPTION
Currently, `joinpath` gives two leading slashes, when an absolute path is joined to an empty URI path. This PR fixes this issue.

```julia
julia> using URIs

julia> u = URI("http://test.com")
URI("http://test.com")

julia> joinpath(u, "/abs/path")
URI("http://test.com//abs/path")
```