### PR TITLE
Fix leading slash for abspath in joinpath (continuation of #62)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "URIs"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 authors = ["Jacob Quinn", "Sam O'Connor", "contributors: https://github.com/JuliaWeb/URIs.jl/graphs/contributors"]
-version = "1.6.2"
+version = "1.6.3"
 
 [compat]
 julia = "1.6"

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -593,7 +593,7 @@ function Base.joinpath(uri::URI, parts::String...)
         end
     end
 
-    if isempty(uri.path)
+    if isempty(uri.path) && !startswith(path, "/")
         path = "/" * path
     end
     return URI(uri; path=normpath(path))

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -656,6 +656,10 @@ end
     joinpath(uri::URI, path::AbstractString) -> URI
 
 Join the path component of URI and other parts.
+
+If `uri` has no authority (host) component, the resulting path must not begin
+with `"//"`, since such a URI cannot be represented (RFC 3986 Section 3.3);
+an `ArgumentError` is thrown in that case.
 """
 function Base.joinpath(uri::URI, parts::String...)
     path = uri.path
@@ -672,7 +676,12 @@ function Base.joinpath(uri::URI, parts::String...)
     if isempty(uri.path) && !startswith(path, "/")
         path = "/" * path
     end
-    return URI(uri; path=normpath(path))
+    path = normpath(path)
+    if isabsent(uri.host) && startswith(path, "//")
+        throw(ArgumentError("URI without authority (host) cannot have a path " *
+                            "beginning with \"//\" (RFC 3986 Section 3.3): $(repr(path))"))
+    end
+    return URI(uri; path=path)
 end
 
 """

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -462,7 +462,7 @@ urltests = URLTest[
         @test URIs.splitpath("/foo/bar") == ["foo", "bar"]
     end
     end
-      
+
     @testset "splitfilepath" begin
         @static if Sys.iswindows()
             data = [
@@ -597,6 +597,9 @@ urltests = URLTest[
         @test joinpath(URIs.URI("http://a.b.c/d/f"), "/b", "c") == URI("http://a.b.c/b/c")
         @test joinpath(URIs.URI("http://a.b.c/"), "b", "c") == URI("http://a.b.c/b/c")
         @test joinpath(URIs.URI("http://a.b.c"), "b", "c") == URI("http://a.b.c/b/c")
+        @test joinpath(URIs.URI("http://a.b.c"), "/b/c/") == URI("http://a.b.c/b/c/")
+        @test joinpath(URIs.URI("http://a.b.c"), "/b/c") == URI("http://a.b.c/b/c")
+        @test joinpath(URIs.URI("http://a.b.c"), "/b", "c") == URI("http://a.b.c/b/c")
     end
 
     @testset "resolvereference" begin

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -615,6 +615,26 @@ urltests = URLTest[
         @test joinpath(URIs.URI("http://a.b.c"), "/b/c/") == URI("http://a.b.c/b/c/")
         @test joinpath(URIs.URI("http://a.b.c"), "/b/c") == URI("http://a.b.c/b/c")
         @test joinpath(URIs.URI("http://a.b.c"), "/b", "c") == URI("http://a.b.c/b/c")
+
+        # absolute paths joined to URIs without an authority (host) component
+        @test string(joinpath(URIs.URI("file:"), "/a/b/c")) == "file:/a/b/c"
+        @test string(joinpath(URIs.URI("file://"), "/a/b/c")) == "file:///a/b/c"
+        @test string(joinpath(URIs.URI(), "/a/b")) == "/a/b"
+        # a path beginning with "//" cannot be represented without an authority
+        # component (RFC 3986 Section 3.3)
+        @test_throws ArgumentError joinpath(URIs.URI("file:"), "//server/share")
+        @test_throws ArgumentError joinpath(URIs.URI(), "//server/share")
+        # with an authority component (even an empty one), "//" paths are fine
+        @test string(joinpath(URIs.URI("file://"), "//server/share")) == "file:////server/share"
+        @test string(joinpath(URIs.URI("http://a.b.c"), "//b/c")) == "http://a.b.c//b/c"
+        # results must round-trip through their string representation
+        for u in (joinpath(URIs.URI("file:"), "/a/b/c"),
+                  joinpath(URIs.URI("file://"), "/a/b/c"),
+                  joinpath(URIs.URI(), "/a/b"),
+                  joinpath(URIs.URI("file://"), "//server/share"),
+                  joinpath(URIs.URI("http://a.b.c"), "//b/c"))
+            @test URI(string(u)) == u
+        end
     end
 
     @testset "resolvereference" begin


### PR DESCRIPTION
Continuation of #62 by @pb866 (the head branch there lives in an org-owned fork, which GitHub doesn't allow maintainer pushes to, so finishing it here — original commits/authorship preserved).

On top of #62's fix for the double leading slash (`joinpath(URI("http://test.com"), "/abs/path")` now correctly gives `http://test.com/abs/path`), this:

- Merges current master into the branch
- Resolves the remaining review point from #62: when the base URI has **no authority component** (e.g. `URI("file:")` or an empty `URI()`), a joined path beginning with `//` is unrepresentable per RFC 3986 §3.3 — serializing it would be re-parsed with the first path segment as the authority, breaking round-tripping. `joinpath` now throws an informative `ArgumentError` in that case.
- Adds regression tests for `file:`, `file://`, empty-URI, and authority-present cases, including string round-trip checks. Note `file://` (empty-but-present authority) serializes as `file:////server/share`, which round-trips fine and remains allowed.
- Bumps the version to 1.6.3

Merging this will mark #62 as merged automatically (its head commit is in this branch's history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)