### PR TITLE
Add tryparse support for URI references

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -50,6 +50,7 @@ true
 
 ```@docs
 URI
+Base.tryparse(::Type{URI}, ::AbstractString)
 queryparams
 queryparampairs
 absuri

--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -203,6 +203,24 @@ parse_uri_reference(str; strict = false) =
 
 Base.parse(::Type{URI}, str::AbstractString) = parse_uri_reference(str)
 
+"""
+    tryparse(URI, str::AbstractString) -> Union{URI,Nothing}
+
+Parse `str` as a URI reference. Return `nothing` instead of throwing a
+`URIs.ParseError` when parsing fails.
+
+Like `parse(URI, str)`, this accepts both absolute URIs and relative URI
+references.
+"""
+function Base.tryparse(::Type{URI}, str::AbstractString)
+    try
+        return parse(URI, str)
+    catch e
+        e isa ParseError && return nothing
+        rethrow()
+    end
+end
+
 function ensurevalid(uri::URI)
     # https://tools.ietf.org/html/rfc3986#section-3.1
     # ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,3 +13,6 @@ end
 Base.codeunits(x::CustomString) = codeunits(x.str)
 
 @test URIs.escapeuri(CustomString("http://example.com")) == URIs.escapeuri("http://example.com")
+
+# `tryparse` must rethrow errors other than parse failures.
+@test_throws MethodError tryparse(URI, CustomString("http://example.com"))

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -500,6 +500,10 @@ urltests = URLTest[
         @test parse(URI, "s3://bucket/key") == URI(host="bucket", path="/key", scheme="s3")
 
         @test sprint(show, parse(URI, "http://google.com")) == "URI(\"http://google.com\")"
+
+        @test tryparse(URI, "http://google.com") == URI("http://google.com")
+        @test tryparse(URI, "../relative/path") == URI("../relative/path")
+        @test tryparse(URI, "http://example.com/\rheader") === nothing
     end
 
     @testset "Characters" begin


### PR DESCRIPTION
## Summary

- implement `Base.tryparse(URI, str)`
- return `nothing` only for `URIs.ParseError`
- document absolute and relative URI-reference behavior
- add success, relative-reference, and malformed-input tests

Closes #60.

## Validation

- Julia 1.6.7: full test suite passed (253 URI tests, 12 URL tests)
- Julia 1.12.6: full test suite passed (253 URI tests, 12 URL tests)
- Documenter build passed

Co-authored by Codex