### PR TITLE
Reject invalid URI authorities

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -7,13 +7,49 @@ export URI,
 
 import Base.==
 
-# Reject carriage return and line feed characters which can lead to CRLF injection
-const _CTL = Set(['\r', '\n'])
+_is_forbidden_ascii(c::Char) = c <= ' ' || c == '\x7f'
 
-function _reject_ctl(s::AbstractString, field::Symbol)
-    if any(c -> c in _CTL, s)
-        throw(ArgumentError("URI $field contains control characters; see RFC 3986 & RFC 9110"))
+function _reject_forbidden_ascii(s::AbstractString, field::Symbol)
+    if any(_is_forbidden_ascii, s)
+        throw(ArgumentError("URI $field contains raw whitespace or control characters; see RFC 3986"))
     end
+end
+
+_is_ascii_digit(c::Char) = '0' <= c <= '9'
+_is_ascii_alpha(c::Char) = 'A' <= c <= 'Z' || 'a' <= c <= 'z'
+_is_hex_digit(c::Char) = _is_ascii_digit(c) || 'A' <= c <= 'F' || 'a' <= c <= 'f'
+_is_unreserved(c::Char) = _is_ascii_alpha(c) || _is_ascii_digit(c) || c in "-._~"
+_is_sub_delim(c::Char) = c in "!\$&'()*+,;="
+_is_userinfo_char(c::Char) = _is_unreserved(c) || _is_sub_delim(c) || c == ':'
+_is_reg_name_char(c::Char) = _is_unreserved(c) || _is_sub_delim(c)
+_is_ip_literal_char(c::Char) = _is_unreserved(c) || _is_sub_delim(c) || c == ':'
+
+function _is_valid_encoded_component(s::AbstractString, valid_ascii::F) where {F}
+    i = firstindex(s)
+    stop = lastindex(s)
+    while i <= stop
+        c = s[i]
+        if c == '%'
+            first_hex = nextind(s, i)
+            first_hex <= stop || return false
+            second_hex = nextind(s, first_hex)
+            second_hex <= stop || return false
+            _is_hex_digit(s[first_hex]) && _is_hex_digit(s[second_hex]) || return false
+            i = nextind(s, second_hex)
+        else
+            isascii(c) && !valid_ascii(c) && return false
+            i = nextind(s, i)
+        end
+    end
+    return true
+end
+
+_is_valid_userinfo(s::AbstractString) = _is_valid_encoded_component(s, _is_userinfo_char)
+function _is_valid_host(s::AbstractString)
+    # The parser removes brackets from IP literals, so ':' distinguishes them
+    # from registered names here.
+    valid_ascii = occursin(':', s) ? _is_ip_literal_char : _is_reg_name_char
+    return _is_valid_encoded_component(s, valid_ascii)
 end
 
 const DEBUG_LEVEL = Ref(0)
@@ -91,16 +127,22 @@ function URI(uri::URI; scheme::AbstractString=uri.scheme,
     end
     querys = query isa AbstractString ? query : escapeuri(query)
 
-    # reject control characters in all components
-    !isabsent(scheme)    && _reject_ctl(scheme, :scheme)
-    !isabsent(userinfo)  && _reject_ctl(userinfo, :userinfo)
-    !isabsent(host)      && _reject_ctl(host, :host)
+    # reject raw ASCII whitespace and control characters in all components
+    !isabsent(scheme)    && _reject_forbidden_ascii(scheme, :scheme)
+    !isabsent(userinfo)  && _reject_forbidden_ascii(userinfo, :userinfo)
+    !isabsent(host)      && _reject_forbidden_ascii(host, :host)
     if port !== absent
-        _reject_ctl(port, :port)
+        _reject_forbidden_ascii(port, :port)
     end
-    !isabsent(path)      && _reject_ctl(path, :path)
-    !isabsent(querys)    && _reject_ctl(querys, :query)
-    !isabsent(fragment)  && _reject_ctl(fragment, :fragment)
+    !isabsent(path)      && _reject_forbidden_ascii(path, :path)
+    !isabsent(querys)    && _reject_forbidden_ascii(querys, :query)
+    !isabsent(fragment)  && _reject_forbidden_ascii(fragment, :fragment)
+    !isabsent(userinfo) && !_is_valid_userinfo(userinfo) &&
+        throw(ArgumentError("Invalid URI userinfo: $userinfo"))
+    !isabsent(host) && !_is_valid_host(host) &&
+        throw(ArgumentError("Invalid URI host: $host"))
+    port !== absent && !all(_is_ascii_digit, port) &&
+        throw(ArgumentError("Invalid URI port: $port"))
 
     return URI(nostring, scheme, userinfo, host, port, path, querys, fragment)
 end
@@ -170,13 +212,13 @@ https://tools.ietf.org/html/rfc3986#section-4.1
 function parse_uri_reference(str::Union{String, SubString{String}};
                              strict = false)
     try
-        _reject_ctl(str, :uri)
+        _reject_forbidden_ascii(str, :uri)
     catch e
         # Keep this path concrete for ahead-of-time compilation. Reading an
         # ArgumentError's abstractly typed message makes the compiler retain
-        # generic string conversion even though _reject_ctl owns the message.
+        # generic string conversion even though _reject_forbidden_ascii owns it.
         e isa ArgumentError && throw(ParseError(
-            "URI uri contains control characters; see RFC 3986 & RFC 9110",
+            "URI uri contains raw whitespace or control characters; see RFC 3986",
         ))
         rethrow()
     end
@@ -191,6 +233,15 @@ function parse_uri_reference(str::Union{String, SubString{String}};
                    group(5, uri_reference_re, str, absent),
                    group(6, uri_reference_re, str, absent),
                    group(7, uri_reference_re, str, absent))
+    if !isabsent(uri.userinfo) && !_is_valid_userinfo(uri.userinfo)
+        throw(ParseError("Invalid URI userinfo: $(uri.userinfo)"))
+    end
+    if !isabsent(uri.host) && !_is_valid_host(uri.host)
+        throw(ParseError("Invalid URI host: $(uri.host)"))
+    end
+    if !isabsent(uri.port) && !all(_is_ascii_digit, uri.port)
+        throw(ParseError("Invalid URI port: $(uri.port)"))
+    end
     if strict
         ensurevalid(uri)
         @ensure uristring(uri) == str

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -346,15 +346,7 @@ urltests = URLTest[
      ), URLTest("ipv6 address with Zone ID, but '%' is not percent-encoded"
      ,"http://[fe80::a%eth0]/"
      ,false
-         ,(Offset(1, 4) # UF_SCHEMA
-         ,Offset(0, 0) # UF_USERINFO
-         ,Offset(9,12) # UF_HOST
-         ,Offset(0, 0) # UF_PORT
-         ,Offset(22, 1) # UF_PATH
-         ,Offset(0, 0) # UF_QUERY
-         ,Offset(0, 0) # UF_FRAGMENT
-         )
-     ,false
+     ,true
      ), URLTest("ipv6 address ending with '%'"
      ,"http://[fe80::a%]/"
      ,false
@@ -370,27 +362,11 @@ urltests = URLTest[
      ), URLTest("tab in URL"
      ,"/foo\tbar/"
      ,false
-         ,(Offset(0, 0) # UF_SCHEMA
-         ,Offset(0, 0) # UF_USERINFO
-         ,Offset(0, 0) # UF_HOST
-         ,Offset(0, 0) # UF_PORT
-         ,Offset(1, 9) # UF_PATH
-         ,Offset(0, 0) # UF_QUERY
-         ,Offset(0, 0) # UF_FRAGMENT
-         )
-     ,false
+     ,true
      ), URLTest("form feed in URL"
      ,"/foo\fbar/"
      ,false
-         ,(Offset(0, 0) # UF_SCHEMA
-         ,Offset(0, 0) # UF_USERINFO
-         ,Offset(0, 0) # UF_HOST
-         ,Offset(0, 0) # UF_PORT
-         ,Offset(1, 9) # UF_PATH
-         ,Offset(0, 0) # UF_QUERY
-         ,Offset(0, 0) # UF_FRAGMENT
-         )
-     ,false
+     ,true
      )
 ]
 
@@ -535,17 +511,45 @@ urltests = URLTest[
         @test_throws URIs.ParseError URIs.parse_uri("ht!tp://google.com", strict=true)
     end
 
-    @testset "Control Characters" begin
+    @testset "Forbidden ASCII Characters" begin
         bad = [
             "http://localhost:1337/ HTTP/1.1\r\nFoo: bar\r\nbaz:",
             "http://example.com/\rpath",
-            "http://example.com/\n"
+            "http://example.com/\n",
+            "http://example.com/a path",
+            "http://exam\tple.com/",
+            "http://example.com/a\fpath",
+            "http://example.com/a\x7fpath",
         ]
         for b in bad
             @test_throws URIs.ParseError parse(URI, b)
         end
         @test_throws ArgumentError URI(; scheme="http", host="example.com\n")
         @test_throws ArgumentError URI(; scheme="http", host="example.com", path="/a\rb")
+        @test_throws ArgumentError URI(; scheme="http", host="example.com", path="/a b")
+    end
+
+    @testset "Invalid Authorities" begin
+        @test_throws URIs.ParseError URI("http://foo@127.0.0.1 @test.com:8080/test")
+        @test_throws URIs.ParseError URI("http://a:b@@hostname:443/")
+        @test_throws URIs.ParseError URI("http://a%GG@hostname/")
+        @test_throws URIs.ParseError URI("//foo.com:bar")
+        @test_throws URIs.ParseError URI("http://example.com:80a/")
+        @test_throws URIs.ParseError URI("http://example.com:\u0661/")
+        for host in ("foo\\bar", "foo|bar", "foo{bar}", "foo]bar", "foo%GGbar")
+            @test_throws URIs.ParseError URI("http://$host/")
+        end
+        @test URI("http://a%40b@foo%41.com/").userinfo == "a%40b"
+        @test URI("http://a%40b@foo%41.com/").host == "foo%41.com"
+        @test URI("http://[fe80::a%25eth0]/").host == "fe80::a%25eth0"
+        @test URI("http://🍕.com/").host == "🍕.com" # Unicode policy is tracked by #41.
+        @test URI("//foo.com:").port == ""
+        @test_throws ArgumentError URI(; scheme="http", userinfo="a@b", host="foo.com")
+        @test_throws ArgumentError URI(; scheme="http", userinfo="a%GG", host="foo.com")
+        @test_throws ArgumentError URI(; scheme="http", host="foo@bar")
+        @test_throws ArgumentError URI(; scheme="http", host="foo%GGbar")
+        @test_throws ArgumentError URI(; scheme="http", host="foo.com", port="bar")
+        @test URI(; scheme="http", host="foo.com", port="") == URI("http://foo.com:")
     end
 
     @testset "parse(URI, str) - $u" for u in urltests


### PR DESCRIPTION
## Summary

- validate user information, hosts, and ports against the RFC 3986 authority grammar
- reject raw ASCII whitespace and control characters in all URI components
- reject extra authority delimiters and malformed percent escapes before DNS or network access
- keep valid empty ports, percent escapes, IPv6 zone escapes, and current Unicode behavior
- update inherited URL cases that treated raw tab, form feed, and malformed zone escapes as valid

Closes #25.
Closes #45.

## Validation

- Julia 1.6.7: full test suite passed (277 URI tests, 12 URL tests)
- Julia 1.12.6: full test suite passed (277 URI tests, 12 URL tests)
- Documenter build and doctests passed
- representative parse and validator paths allocate 0 bytes after compilation

Co-authored by Codex