### PR TITLE
Encode `escapeuri` byte by byte so it resolves under `--trim`

### DIFF
--- a/src/URIs.jl
+++ b/src/URIs.jl
@@ -521,8 +521,26 @@ Apply URI percent-encoding to escape special characters in `x`.
 function escapeuri end
 
 escapeuri(c::Char) = string('%', uppercase(string(Int(c), base=16, pad=2)))
-escapeuri(str::AbstractString, safe::Function=issafe) =
-    join(safe(c) ? c : escapeuri(c) for c in utf8_chars(str))
+
+@inline hexdigit(b::UInt8) = b < 0xa ? UInt8('0') + b : UInt8('A') + (b - 0xa)
+
+# Encoding byte by byte keeps this method resolvable under `--trim`; `join` over a
+# generator reaches `Base.AnnotatedString`, which trimming cannot resolve.
+function escapeuri(str::AbstractString, safe::Function=issafe)
+    bytes = _bytes(str)
+    out = UInt8[]
+    sizehint!(out, length(bytes))
+    for b in bytes
+        c = Char(b)
+        if safe(c)
+            # `safe` judges a `Char`, so a kept byte above 0x7f goes out UTF-8 encoded.
+            b < 0x80 ? push!(out, b) : append!(out, codeunits(string(c)))
+        else
+            push!(out, UInt8('%'), hexdigit(b >> 4), hexdigit(b & 0xf))
+        end
+    end
+    return String(out)
+end
 
 escapeuri(bytes::Vector{UInt8}) = bytes
 escapeuri(v::Number) = escapeuri(string(v))

--- a/test/uri.jl
+++ b/test/uri.jl
@@ -507,6 +507,10 @@ urltests = URLTest[
         @test unescapeuri(escapeuri("abcdef 1234-=~!@#\$()_+{}|[]a;")) == "abcdef 1234-=~!@#\$()_+{}|[]a;"
         @test unescapeuri(escapeuri("👽")) == "👽"
 
+        @test escapeuri("a~b/c", c -> c == '~' || URIs.issafe(c)) == "a~b%2Fc"
+        # a `safe` that keeps a byte above 0x7f gets that character, UTF-8 encoded
+        @test escapeuri("αβ", c -> true) == escapeuri("αβ", isvalid) == "\u00ce\u00b1\u00ce\u00b2"
+
         @test escapeuri([("foo", "bar"), (1, 2)]) == "foo=bar&1=2"
         @test escapeuri(Dict(["foo" => "bar", 1 => 2])) in ("1=2&foo=bar", "foo=bar&1=2")
         @test escapeuri(["foo" => "bar", 1 => 2]) == "foo=bar&1=2"


### PR DESCRIPTION
`escapeuri(::AbstractString, ::Function)` builds its result with `join` over a generator, which routes through `Base.AnnotatedString` — a path `--trim` cannot resolve. One call to `escapeuri` on a `String` fails a `juliac --experimental --trim=safe` build with 20 verifier errors.

A byte loop appending to a `Vector{UInt8}` does the same job and resolves.

Measured on Julia 1.12.7:

- **Output is identical.** 1,202,368 comparisons against the v1.7.0 implementation, zero mismatches.
- **Verifier errors 20 → 0.** A `@main` calling `escapeuri("hello world/foo?a=1&b=ü")` now builds with `juliac --output-exe --experimental --trim=safe` and prints the right answer; so do programs calling `escapepath` and a custom predicate.
- **Tests pass**, 304/304, including two new assertions for the `safe` argument, which had none.
- **Faster** (`@btime`):

  | input | v1.7.0 | here |
  |---|---|---|
  | 205-byte query string | 4.97 µs, 16.1 KiB | 796 ns, 1.25 KiB |
  | 88-byte path via `escapepath` | 979 ns, 448 B | 345 ns, 256 B |
  | `"hello world"` | 291 ns, 592 B | 56 ns, 176 B |

Made by Claude
